### PR TITLE
Improve the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,24 @@ jobs:
       matrix:
         compiler: [gcc, clang]
         buildtype: [debug, debugoptimized, release]
-#        checker: [off, asan, valgrind, ubsan]
+        checker: [off, address, valgrind, undefined]
     container:
       image: opensuse/tumbleweed
 
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: zypper --non-interactive in gcc clang make libnetlink-devel libnl3-devel libjson-c-devel meson ethtool python3 python3-devel python3-cffi git
+      run: zypper --non-interactive in gcc clang make libnetlink-devel libnl3-devel libjson-c-devel meson ethtool python3 python3-devel python3-cffi git valgrind
+
+    - name: configure
+      run: meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=${{ matrix.buildtype }} -Db_sanitize=${{ matrix.checker }} build
+      if: ${{ (matrix.checker == 'address') || (matrix.checker == 'undefined') }}
+      env:
+        CC: ${{ matrix.compiler }}
 
     - name: configure
       run: meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=${{ matrix.buildtype }} build
+      if: ${{ (matrix.checker != 'address') && (matrix.checker != 'undefined') }}
       env:
         CC: ${{ matrix.compiler }}
 
@@ -29,9 +36,15 @@ jobs:
       run: meson compile
       working-directory: ./build
 
+    - name: test (with valgrind)
+      run: meson test --wrap=valgrind
+      working-directory: ./build
+      if: ${{ matrix.checker == 'valgrind' }}
+
     - name: test
       run: meson test
       working-directory: ./build
+      if: ${{ matrix.checker != 'valgrind' }}
 
     - name: lint
       run: ninja clang-tidy
@@ -47,5 +60,5 @@ jobs:
       uses: 'actions/upload-artifact@v2'
       if: ${{ always() }}
       with:
-        name: build-dir ${{ matrix.compiler }}-${{ matrix.buildtype }}
+        name: build-dir ${{ matrix.compiler }}-${{ matrix.buildtype }}-${{ matrix.checker }}
         path: ./build

--- a/headers/types.h
+++ b/headers/types.h
@@ -28,7 +28,7 @@ typedef struct app_settings_s {
     unsigned int grace_period;
     double stats_collection_period;
     double inference_loop_period;
-    const char *plugins_path;
+    char plugins_path[MAX_FILENAME_LENGTH];
 } app_settings_t;
 
 #define USEC_IN_SEC 1000000 /* Expressed in microseconds; 1s = 10^6usec */

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,10 @@ options = [
   ['m_threads', 'M_THREADS']
 ]
 
+if get_option('b_sanitize') == 'undefined'
+  add_global_arguments('-fno-sanitize-recover', language : 'c')
+endif
+
 foreach opt : options
   if get_option(opt[0])
     add_project_arguments('-D@0@'.format(opt[1]), language : 'c')

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,12 @@ if get_option('b_sanitize') == 'undefined'
   add_global_arguments('-fno-sanitize-recover', language : 'c')
 endif
 
+if cc.get_id() == 'clang' and (
+  get_option('b_sanitize') == 'undefined' or get_option('b_sanitize') == 'address'
+)
+  add_project_link_arguments('-shared-libasan', language : 'c')
+endif
+
 foreach opt : options
   if get_option(opt[0])
     add_project_arguments('-D@0@'.format(opt[1]), language : 'c')

--- a/scripts/collect_stats.py
+++ b/scripts/collect_stats.py
@@ -89,6 +89,7 @@ def compile_module(output_filename):
     # Doing it manually for now
     definitions += '''\
     #define MAX_CPU_NAME_LENGTH 7
+    #define MAX_FILENAME_LENGTH 255
     #define MAX_INTERFACE_NAME_LENGTH 255
     '''
 

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -8,7 +8,7 @@ abi_src = custom_target(
 )
 abi = shared_library(
   '_phoebe.abi3',
-  [abi_src, meson.project_source_root() / 'src' / 'stats.c'] + common_src,
+  abi_src, stat_src, common_src,
   name_prefix : '',
   dependencies : [prog_python.dependency(embed : true), common_dep, nl_nf_3]
 )

--- a/src/filehelper.c
+++ b/src/filehelper.c
@@ -201,7 +201,10 @@ int readSettingsFromJsonFile(char *settingsFileName, app_settings_t *settings,
     settings->inference_loop_period =
         json_object_get_double(inference_loop_period);
 
-    settings->plugins_path = json_object_get_string(plugins_path);
+    assert(sizeof(settings->plugins_path) >
+           json_object_get_string_len(plugins_path));
+    memcpy(settings->plugins_path, json_object_get_string(plugins_path),
+           json_object_get_string_len(plugins_path) + 1);
 
     write_adv_log("settings->plugins_path: %s\n", settings->plugins_path);
 
@@ -251,6 +254,8 @@ int readSettingsFromJsonFile(char *settingsFileName, app_settings_t *settings,
     write_adv_log("errors_rate_weight: %lf\n", weights->errors_rate_weight);
     write_adv_log("fifo_errors_rate_weight: %lf\n",
                   weights->fifo_errors_rate_weight);
+
+    json_object_put(parsed_json);
 
     if ((weights->transfer_rate_weight + weights->drop_rate_weight +
          weights->errors_rate_weight + weights->fifo_errors_rate_weight) > 1) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,6 @@
-common_src = [
-  meson.current_source_dir() / 'filehelper.c',
-  meson.current_source_dir() / 'utils.c'
-]
+common_src = files('filehelper.c', 'utils.c')
+stat_src = files('stats.c')
+
 common_dep = declare_dependency(
   dependencies : [nl3, json_c, pthread, m, dl],
   include_directories : incdir
@@ -10,13 +9,13 @@ common_dep = declare_dependency(
 plugins = [
   shared_library(
     'network_plugin',
-    ['network_plugin.c', 'stats.c', 'algorithmic.c'] + common_src,
+    ['network_plugin.c', 'stats.c', 'algorithmic.c'], common_src,
     dependencies : [nl_nf_3, common_dep]
   )
 ]
 
 phoebe = executable(
   'phoebe',
-  ['phoebe.c'] + common_src,
+  'phoebe.c', common_src,
   dependencies : common_dep
 )

--- a/src/utils.c
+++ b/src/utils.c
@@ -226,8 +226,14 @@ extern inline double calcDerivedValue(tuning_params_t *parameters,
         res = calculateDerivedValue(transferRate,
                                     parameters[refIndex].transfer_rate,
                                     referenceValue, epsilon);
-        res = adjustValue(pivot, refIndex, res, pivotPrevValue, pivotNextValue,
-                          epsilon, approx_function);
+        if (res > UINT_MAX || res < 0.) {
+            write_adv_log("value res is out of range for unsigned int: %e\n",
+                          res);
+        }
+        const unsigned int refIndex =
+            res > UINT_MAX ? UINT_MAX : (res < 0 ? 0 : res);
+        res = adjustValue(pivot, refIndex, refIndex, pivotPrevValue,
+                          pivotNextValue, epsilon, approx_function);
     }
     return res;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,7 +1,20 @@
 test_script = find_program(meson.current_source_dir() / 'run_tests.sh')
 
+# When building with clang we use -shared-libasan, but clang's shared ASAS/UBSAN
+# is not in the default library search path. Thus we must add it manually to
+# LD_LIBRARY_PATH and check first that the library is actually where we expect
+# it to be
+if cc.get_id() == 'clang'
+  base_path = '/usr' / get_option('libdir') / 'clang' / cc.version() / 'lib/linux/'
+  libclang_rt = cc.find_library(base_path / 'libclang_rt.asan-@0@'.format(build_machine.cpu_family()))
+  env = ['LD_LIBRARY_PATH=@0@'.format(base_path)]
+else
+  env = []
+endif
+
 test(
   'integration test',
   test_script,
-  args : [meson.project_source_root(), meson.project_build_root()]
+  args : [meson.project_source_root(), meson.project_build_root()],
+  env : env
 )


### PR DESCRIPTION
This PR extends the existing CI infrastructure to also add runs with ASAN, UBSAN and valgrind. This required two fixes:
- There is a memory leak in the json parsing code (this was fixed by @shunghsiyu on gitlab)
- https://github.com/SUSE/phoebe/blob/43b34f752a40e6a77175586ed4e382cf875d17b9/src/utils.c#L229 can result in a truncation of `res` as it exceeds the `unsigned int` range which is undefined behavior.