### PR TITLE
Disable building of shared library needed by collect_stats.py by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
       run: zypper --non-interactive in gcc clang make libnetlink-devel libnl3-devel libjson-c-devel meson ethtool python3 python3-devel python3-cffi git valgrind
 
     - name: configure
-      run: meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=${{ matrix.buildtype }} -Db_sanitize=${{ matrix.checker }} build
+      run: meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dcollector=enabled -Dbuildtype=${{ matrix.buildtype }} -Db_sanitize=${{ matrix.checker }} build
       if: ${{ (matrix.checker == 'address') || (matrix.checker == 'undefined') }}
       env:
         CC: ${{ matrix.compiler }}
 
     - name: configure
-      run: meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=${{ matrix.buildtype }} build
+      run: meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dcollector=enabled -Dbuildtype=${{ matrix.buildtype }} build
       if: ${{ (matrix.checker != 'address') && (matrix.checker != 'undefined') }}
       env:
         CC: ${{ matrix.compiler }}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,3 +22,7 @@ option(
   'm_threads', type : 'boolean', value : false,
   description : 'when enabled will run training using as many threads as cores are available on the machine'
 )
+option(
+  'collector', type : 'feature', value : 'auto',
+  description : 'when enabled will build library requires for collect_stats.py, which is used to collect system metrics to train the AI model'
+)

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,14 +1,16 @@
-prog_python = import('python').find_installation('python3')
+prog_python = import('python').find_installation('python3', required : false, modules : ['cffi'])
 
-abi_src = custom_target(
-  '_phoebe.c',
-  input : ['collect_stats.py'],
-  output : ['_phoebe.c'],
-  command : [prog_python, '@INPUT@', 'generate', '@OUTPUT@']
-)
-abi = shared_library(
-  '_phoebe.abi3',
-  abi_src, stat_src, common_src,
-  name_prefix : '',
-  dependencies : [prog_python.dependency(embed : true), common_dep, nl_nf_3]
-)
+if prog_python.found()
+  abi_src = custom_target(
+    '_phoebe.c',
+    input : ['collect_stats.py'],
+    output : ['_phoebe.c'],
+    command : [prog_python, '@INPUT@', 'generate', '@OUTPUT@'],
+  )
+  abi = shared_library(
+    '_phoebe.abi3',
+    abi_src, stat_src, common_src,
+    name_prefix : '',
+    dependencies : [prog_python.dependency(embed : true), common_dep, nl_nf_3],
+  )
+endif

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,4 +1,4 @@
-prog_python = import('python').find_installation('python3', required : false, modules : ['cffi'])
+prog_python = import('python').find_installation('python3', required : get_option('collector'), modules : ['cffi'])
 
 if prog_python.found()
   abi_src = custom_target(


### PR DESCRIPTION
The `_phoebe.abi3.so` shared library is used by collect_stats.py to retrieve various system metric; and the shared library itself requires python3-cffi to generate the binding (`_phoebe.c`).

On Linux distribution that doesn't come with a python3-cffi package is becomes a problem, while there are other ways to install python3-cffi (e.g. `pip3 install cffi`), doing so it not ideal when building the phoebe package itself.

Thus the easiest way to deal with the problem is disable building of `_phoebe.abi3.so` by default so packaging doesn't need python3-cffi, and explicitly enable it in our CI. 