### PR TITLE
Memory-related fixes reported by Valgrind and GCC

### DIFF
--- a/src/filehelper.c
+++ b/src/filehelper.c
@@ -149,7 +149,8 @@ int writeRow(FILE *fp, tuning_params_t *row) {
 int readSettingsFromJsonFile(char *settingsFileName, app_settings_t *settings,
                              weights_reference_t *weights, double *bias) {
     FILE *fp;
-    char buffer[BUFFER_SIZE];
+    size_t read_size;
+    char buffer[BUFFER_SIZE + 1];
 
     struct json_object *parsed_json;
     struct json_object *transfer_rate_weight;
@@ -172,7 +173,8 @@ int readSettingsFromJsonFile(char *settingsFileName, app_settings_t *settings,
     if ((fp = fopen(settingsFileName, "r")) == NULL)
         return RET_FAIL;
 
-    fread(buffer, BUFFER_SIZE, 1, fp);
+    read_size = fread(buffer, 1, BUFFER_SIZE, fp);
+    buffer[read_size] = '\0';
     fclose(fp);
 
     parsed_json = json_tokener_parse(buffer);

--- a/src/phoebe.c
+++ b/src/phoebe.c
@@ -191,7 +191,7 @@ int registerAllPlugins() {
     void *handle;
     char *error;
 
-    char resolved_path[MAX_FILENAME_LENGTH * 2];
+    char resolved_path[MAX_FILENAME_LENGTH * 2 + 1];
     DIR *d;
     struct dirent *dir;
 


### PR DESCRIPTION
Two minor fixes:
* Zero-terminate the string read by fread() - fix Valgrind's warning of "conditional jump or move depends on uninitialised value(s)"
* Expand resolved_path by 1 byte - fix GCC's warning of possible overflow