### PR TITLE
Refactors and workarounds so testing of collect_stats.py can be enabled in CI

### DIFF
--- a/scripts/collect_stats.py
+++ b/scripts/collect_stats.py
@@ -184,15 +184,7 @@ def collect_stats(
     nproc = phoebe.get_nprocs()
     row.cores = nproc
 
-    # TODO: what if other CPUs use different governor
-    with open(SYSFS_CPU_PATH + 'cpu0/cpufreq/scaling_governor') as f:
-        cpu_governor = f.read().strip()
-    row.governor = phoebe.cpuGovernorIndex(cpu_governor.encode('ascii'))
-
-    # TODO: what if other CPUs has different frequency
-    with open(SYSFS_CPU_PATH + 'cpu0/cpufreq/scaling_cur_freq') as f:
-        cpu_freq = int(f.read().strip())
-    row.cpu_speed = cpu_freq
+    # TODO: bring back reading of scaling_governor and scaling_cur_freq
 
     phoebe.readCpuStats(cpu_stats_ptr)
     busy_percentage = phoebe.calculateCpuBusyPercentage(prev_cpu_stats_ptr, cpu_stats_ptr)

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -4,10 +4,11 @@ prog_python = import('python').find_installation(
   modules : ['cffi'],
   disabler : true,
 )
+collector_script = files('collect_stats.py')
 
 abi_src = custom_target(
   '_phoebe.c',
-  input : ['collect_stats.py'],
+  input : [collector_script],
   output : ['_phoebe.c'],
   command : [prog_python, '@INPUT@', 'generate', '@OUTPUT@'],
 )

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,16 +1,19 @@
-prog_python = import('python').find_installation('python3', required : get_option('collector'), modules : ['cffi'])
+prog_python = import('python').find_installation(
+  'python3',
+  required : get_option('collector'),
+  modules : ['cffi'],
+  disabler : true,
+)
 
-if prog_python.found()
-  abi_src = custom_target(
-    '_phoebe.c',
-    input : ['collect_stats.py'],
-    output : ['_phoebe.c'],
-    command : [prog_python, '@INPUT@', 'generate', '@OUTPUT@'],
-  )
-  abi = shared_library(
-    '_phoebe.abi3',
-    abi_src, stat_src, common_src,
-    name_prefix : '',
-    dependencies : [prog_python.dependency(embed : true), common_dep, nl_nf_3],
-  )
-endif
+abi_src = custom_target(
+  '_phoebe.c',
+  input : ['collect_stats.py'],
+  output : ['_phoebe.c'],
+  command : [prog_python, '@INPUT@', 'generate', '@OUTPUT@'],
+)
+abi = shared_library(
+  '_phoebe.abi3',
+  abi_src, stat_src, common_src,
+  name_prefix : '',
+  dependencies : [prog_python.dependency(embed : true), common_dep, nl_nf_3],
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-test_script = find_program(meson.current_source_dir() / 'run_tests.sh')
+setup_script = find_program(meson.current_source_dir() / 'setup.sh')
 
 # When building with clang we use -shared-libasan, but clang's shared ASAS/UBSAN
 # is not in the default library search path. Thus we must add it manually to
@@ -18,4 +18,24 @@ else
   args = [meson.source_root(), meson.build_root()]
 endif
 
-test('integration test', test_script, args : args, env : env)
+test(
+  'integration test setup',
+  setup_script,
+  args : args,
+  priority : 1000,
+  is_parallel : false
+)
+test(
+  'integration test (main)',
+  phoebe,
+  args : ['-s', 'settings.json', '-f', 'rates.csv', '-m', 'training'],
+  env : env,
+)
+# disabled until we solve https://github.com/SUSE/phoebe/issues/2
+#test(
+#  'integration test (collector)',
+#  collector_script,
+#  args : ['lo', '1'],
+#  depends : [abi],
+#  env : env,
+#)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,10 +6,26 @@ setup_script = find_program(meson.current_source_dir() / 'setup.sh')
 # it to be
 if cc.get_id() == 'clang'
   base_path = '/usr' / get_option('libdir') / 'clang' / cc.version() / 'lib/linux/'
-  libclang_rt = cc.find_library(base_path / 'libclang_rt.asan-@0@'.format(build_machine.cpu_family()))
   env = ['LD_LIBRARY_PATH=@0@'.format(base_path)]
 else
   env = []
+endif
+
+# ASAN requies its runtime to be loaded first, which is a problem when we run
+# collect_stats.py since the Python executable that comes with the distro won't
+# do that. So we find the ASAN runtime manually here and add it to LD_PRELOAD
+# later.
+if not get_option('b_sanitize').contains('address')
+  libasan = ''
+elif cc.get_id() == 'clang'
+  libasan = run_command(
+    cc,
+    '-print-file-name=libclang_rt.asan-@0@.so'.format(build_machine.cpu_family()),
+  ).stdout().strip()
+elif cc.get_id() == 'gcc'
+  libasan = run_command(cc, '-print-file-name=libasan.so').stdout().strip()
+else
+  error('Unsupported compiler to use with address sanitizer')
 endif
 
 if meson.version().version_compare('>=0.56.0')
@@ -17,6 +33,12 @@ if meson.version().version_compare('>=0.56.0')
 else
   args = [meson.source_root(), meson.build_root()]
 endif
+
+python_env = env + [
+  'PYTHONPATH=@0@'.format(args[1] / 'scripts'),
+  'LD_PRELOAD=@0@'.format(libasan),
+  'ASAN_OPTIONS=detect_leaks=0',
+]
 
 test(
   'integration test setup',
@@ -37,5 +59,5 @@ test(
 #  collector_script,
 #  args : ['lo', '1'],
 #  depends : [abi],
-#  env : env,
+#  env : python_env,
 #)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,9 +6,9 @@ setup_script = find_program(meson.current_source_dir() / 'setup.sh')
 # it to be
 if cc.get_id() == 'clang'
   base_path = '/usr' / get_option('libdir') / 'clang' / cc.version() / 'lib/linux/'
-  env = ['LD_LIBRARY_PATH=@0@'.format(base_path)]
+  env = {'LD_LIBRARY_PATH': base_path}
 else
-  env = []
+  env = {}
 endif
 
 # ASAN requies its runtime to be loaded first, which is a problem when we run
@@ -34,11 +34,11 @@ else
   args = [meson.source_root(), meson.build_root()]
 endif
 
-python_env = env + [
-  'PYTHONPATH=@0@'.format(args[1] / 'scripts'),
-  'LD_PRELOAD=@0@'.format(libasan),
-  'ASAN_OPTIONS=detect_leaks=0',
-]
+python_env = env + {
+  'PYTHONPATH': args[1] / 'scripts',
+  'LD_PRELOAD': libasan,
+  'ASAN_OPTIONS': 'detect_leaks=0',
+}
 
 test(
   'integration test setup',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -53,11 +53,10 @@ test(
   args : ['-s', 'settings.json', '-f', 'rates.csv', '-m', 'training'],
   env : env,
 )
-# disabled until we solve https://github.com/SUSE/phoebe/issues/2
-#test(
-#  'integration test (collector)',
-#  collector_script,
-#  args : ['lo', '1'],
-#  depends : [abi],
-#  env : python_env,
-#)
+test(
+  'integration test (collector)',
+  collector_script,
+  args : ['lo', '1'],
+  depends : [abi],
+  env : python_env,
+)

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -31,7 +31,3 @@ cat <<EOF > settings.json
 EOF
 
 cp ${SRC_DIR}/csv_files/rates.csv .
-
-${BUILD_DIR}/src/phoebe -s settings.json -f rates.csv -m training
-# disabled until we solve https://github.com/SUSE/phoebe/issues/2
-# PYTHONPATH=${BUILD_DIR}/scripts/ ${SRC_DIR}/scripts/collect_stats.py lo 1


### PR DESCRIPTION
This pull requests contains a series of commits to refactor/workaround several blockers that prevented us from testing collect_stat.py in CI.
- Remove access to sysfs CPU device in collect_stats.py 
- Disable ASAN leak detection when testing collect_stats.py
- Give the libasan in LD_PRELOAD when testing collect_stats.py