### PR TITLE
Fix installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,18 @@ jobs:
       working-directory: ./build
       if: ${{ matrix.checker != 'valgrind' }}
 
+    - name: install
+      run: |
+        set -euox pipefail
+        mkdir destdir
+        DESTDIR=./destdir meson install
+        [ -e destdir/usr/local/etc/phoebe/settings.json ]
+        [ -e destdir/usr/local/share/phoebe/rates.csv ]
+        [ -e destdir/usr/local/bin/phoebe ]
+        [ -e destdir/usr/local/lib64/phoebe/libnetwork_plugin.so ]
+      working-directory: ./build
+      if: ${{ matrix.checker == 'off' }}
+
     - name: upload build directory
       uses: 'actions/upload-artifact@v2'
       if: ${{ always() }}

--- a/csv_files/meson.build
+++ b/csv_files/meson.build
@@ -1,0 +1,2 @@
+csv = files('rates.csv')
+install_data(csv)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('Phoeβe', 'c', default_options : ['c_std=gnu99', 'warning_level=2'])
+project('phoebe', 'c', default_options : ['c_std=gnu99', 'warning_level=2'])
 
 incdir = include_directories('headers')
 

--- a/meson.build
+++ b/meson.build
@@ -39,3 +39,4 @@ endforeach
 subdir('src')
 subdir('scripts')
 subdir('tests')
+subdir('csv_files')

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,12 +10,16 @@ plugins = [
   shared_library(
     'network_plugin',
     ['network_plugin.c', 'stats.c', 'algorithmic.c'], common_src,
-    dependencies : [nl_nf_3, common_dep]
+    dependencies : [nl_nf_3, common_dep],
+    install : true,
+    install_dir : get_option('libdir') / meson.project_name()
   )
 ]
 
 phoebe = executable(
   'phoebe',
   'phoebe.c', common_src,
-  dependencies : common_dep
+  dependencies : common_dep,
+  install : true,
+  install_dir : get_option('bindir')
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,6 @@
+settings_json = files('settings.json')
+install_data(settings_json, install_dir : get_option('sysconfdir') / meson.project_name())
+
 setup_script = find_program(meson.current_source_dir() / 'setup.sh')
 
 # When building with clang we use -shared-libasan, but clang's shared ASAS/UBSAN


### PR DESCRIPTION
This pull request adds support to install phoeβe:
- `phoebe` -> `$bindir/phoebe`
- `settings.json` -> `$sysconfdir/phoebe/settings.json`
- `$plugin` -> `$libdir/phoebe/$plugin`
- `rates.csv` -> `$datadir/phoebe/rates.csv`

It should work in rpm via `%meson`, `%meson_build` and `%meson_install`.