### PR TITLE
Add rpmbuild ci

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -1,0 +1,62 @@
+name: Build RPMs
+
+on: [push, pull_request]
+
+jobs:
+  build_srpm:
+    runs-on: ubuntu-latest
+    container:
+      image: "fedora:latest"
+      options: --privileged
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: install mock
+      run: dnf --setopt=install_weak_deps=False install -y mock git
+
+    - name: build source RPM
+      run: |
+        export VERSION=0.1
+        git archive --format=tar.gz --output=phoebe-${VERSION}.tar.gz --prefix=phoebe-${VERSION}/ HEAD
+        mock -r /etc/mock/opensuse-tumbleweed-x86_64.cfg \
+            --isolation=simple --buildsrpm \
+            --sources=phoebe-${VERSION}.tar.gz \
+            --spec=dist/rpm/phoebe.spec --resultdir=srpm_res
+
+    - name: upload source rpm
+      uses: 'actions/upload-artifact@v2'
+      with:
+        name: srpm_res
+        path: ./srpm_res
+
+  build_rpm:
+    runs-on: ubuntu-latest
+    needs: build_srpm
+    container:
+      image: "fedora:latest"
+      options: --privileged
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ["opensuse-leap-15.2", "opensuse-tumbleweed"]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: srpm_res
+
+    - name: install mock
+      run: dnf --setopt=install_weak_deps=False install -y mock
+
+    - name: build rpm
+      run: mock -r /etc/mock/${{ matrix.target }}-x86_64.cfg --isolation=simple --resultdir=rpms/ *.src.rpm
+
+    - name: upload rpm
+      uses: 'actions/upload-artifact@v2'
+      with:
+        name: phoebe-${{ matrix.target }}.x86_64.rpm
+        path: ./rpms/*.x86_64.rpm

--- a/release.md
+++ b/release.md
@@ -1,0 +1,5 @@
+# Create a new phoebe release
+
+- Create a new tag via git
+- Bump the `Version: ` field in `dist/rpm/phoebe.spec`
+- Bump the `VERSION` variable in `.github/workflows/rpmbuild.yml`


### PR DESCRIPTION
This pull request adds a github action, that builds a source rpm and a rpm for opensuse Leap 15.2 and Tumbleweed using mock. This might yield slightly different results than on obs, but we get instant feedback if the spec file is broken.