### PR TITLE
Make the spec cross distribution compatible

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -40,7 +40,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["opensuse-leap-15.2", "opensuse-tumbleweed", "fedora-rawhide", "fedora-33", "fedora-32"]
+        target:
+          - "opensuse-leap-15.2"
+          - "opensuse-tumbleweed"
+          - "fedora-rawhide"
+          - "fedora-33"
+          - "fedora-32"
+          - "centos-stream"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["opensuse-leap-15.2", "opensuse-tumbleweed"]
+        target: ["opensuse-leap-15.2", "opensuse-tumbleweed", "fedora-rawhide", "fedora-33", "fedora-32"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -58,5 +58,5 @@ jobs:
     - name: upload rpm
       uses: 'actions/upload-artifact@v2'
       with:
-        name: phoebe-${{ matrix.target }}.x86_64.rpm
+        name: phoebe-${{ matrix.target }}.x86_64.rpm.zip
         path: ./rpms/*.x86_64.rpm

--- a/dist/rpm/phoebe.spec
+++ b/dist/rpm/phoebe.spec
@@ -23,10 +23,11 @@ Summary:        Phoeβe wants to add basic artificial intelligence capabilities 
 License:        BSD-3-Clause
 URL:            https://github.com/SUSE/%{name}
 Source:         %{URL}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-BuildRequires:  libjson-c-devel
-BuildRequires:  libnl3-devel
+BuildRequires:  pkgconfig(json-c)
+BuildRequires:  pkgconfig(libnl-3.0)
+BuildRequires:  pkgconfig(libnl-nf-3.0)
 BuildRequires:  meson
-BuildRequires:  ninja
+BuildRequires:  gcc
 BuildRequires:  python3-cffi
 BuildRequires:  python3-devel
 BuildRequires:  python3-pycparser


### PR DESCRIPTION
The spec file only needed a few tiny changes to work on Fedora and CentOS Stream as well.

It does not work on CentOS 8 and older, as their meson version is too old. But we're facing the same issue on Leap <= 15.1/SLE <= SP1 and that was not a blocker.