### PR TITLE
Rename APPLY_SETTINGS macro

### DIFF
--- a/src/network_plugin.c
+++ b/src/network_plugin.c
@@ -128,7 +128,7 @@ void applySettings(char *interfaceName, tuning_params_t *parameters,
     write_log("$ %s\n", netIPCommand);
     write_log("$ %s\n", ringSizeCommand);
     write_log("$ %s\n", offloadCommand);
-#ifdef APPLY_SETTINGS
+#ifdef APPLY_CHANGES
     system(netCoreCommand);
     system(netIPCommand);
     system(ringSizeCommand);


### PR DESCRIPTION
`src/network_plugin.c` expects APPLY_SETTINGS, but in the build system we provides APPLY_CHANGES.