### PR TITLE
Fix rpmbuild

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -44,6 +44,7 @@ jobs:
           - "opensuse-leap-15.2"
           - "opensuse-tumbleweed"
           - "fedora-rawhide"
+          - "fedora-34"
           - "fedora-33"
           - "fedora-32"
           - "centos-stream-8"

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -46,7 +46,7 @@ jobs:
           - "fedora-rawhide"
           - "fedora-33"
           - "fedora-32"
-          - "centos-stream"
+          - "centos-stream-8"
 
     steps:
     - uses: actions/checkout@v1

--- a/dist/rpm/phoebe.spec
+++ b/dist/rpm/phoebe.spec
@@ -62,6 +62,7 @@ to offer eventually the best possible setup.
 %license LICENSE
 %doc README.md SETUP.md
 %{_bindir}/%{name}
+%{_bindir}/data_tool
 %dir %{_libdir}/%{name}
 %dir %{_datadir}/%{name}
 %dir %{_sysconfdir}/%{name}


### PR DESCRIPTION
There were two issues in the CI:
- the `data_tool` binary is being installed, but is missing in `%files` in the spec
- `centos-stream` got renamed to `centos-stream-8`