### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
       working-directory: ./build
 
     - name: test (with valgrind)
-      run: meson test --wrap=valgrind
+      run: meson test --wrap=valgrind || (cat meson-logs/testlog-valgrind.txt && exit 1)
       working-directory: ./build
       if: ${{ matrix.checker == 'valgrind' }}
 
     - name: test
-      run: meson test
+      run: meson test || (cat meson-logs/testlog.txt && exit 1)
       working-directory: ./build
       if: ${{ matrix.checker != 'valgrind' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         [ -e destdir/usr/local/etc/phoebe/settings.json ]
         [ -e destdir/usr/local/share/phoebe/rates.csv ]
         [ -e destdir/usr/local/bin/phoebe ]
+        [ -e destdir/usr/local/bin/data_tool ]
         [ -e destdir/usr/local/lib64/phoebe/libnetwork_plugin.so ]
       working-directory: ./build
       if: ${{ matrix.checker == 'off' }}

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -12,8 +12,17 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: install mock
-      run: dnf --setopt=install_weak_deps=False install -y mock git
+    - name: Cache mock cache
+      uses: actions/cache@v2
+      with:
+        path: mock_cache
+        key: srpm_root
+
+    - name: install & configure mock
+      run: |
+        mkdir -p mock_cache
+        dnf --setopt=install_weak_deps=False install -y mock git
+        echo config_opts[\'cache_topdir\'] = \"$(pwd)/mock_cache\" >> /etc/mock/site-defaults.cfg
 
     - name: build source RPM
       run: |
@@ -52,12 +61,21 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Cache mock cache
+      uses: actions/cache@v2
+      with:
+        path: mock_cache
+        key: rpm_root_${{ matrix.target }}
+
     - uses: actions/download-artifact@v2
       with:
         name: srpm_res
 
     - name: install mock
-      run: dnf --setopt=install_weak_deps=False install -y mock
+      run: |
+        mkdir -p mock_cache
+        dnf --setopt=install_weak_deps=False install -y mock
+        echo config_opts[\'cache_topdir\'] = \"$(pwd)/mock_cache\" >> /etc/mock/site-defaults.cfg
 
     - name: build rpm
       run: mock -r /etc/mock/${{ matrix.target }}-x86_64.cfg --isolation=simple --resultdir=rpms/ *.src.rpm

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         export VERSION=0.1
         git archive --format=tar.gz --output=phoebe-${VERSION}.tar.gz --prefix=phoebe-${VERSION}/ HEAD
-        mock -r /etc/mock/opensuse-tumbleweed-x86_64.cfg \
+        mock -r /etc/mock/opensuse-tumbleweed-x86_64.cfg --verbose \
             --isolation=simple --buildsrpm \
             --sources=phoebe-${VERSION}.tar.gz \
             --spec=dist/rpm/phoebe.spec --resultdir=srpm_res
@@ -78,7 +78,7 @@ jobs:
         echo config_opts[\'cache_topdir\'] = \"$(pwd)/mock_cache\" >> /etc/mock/site-defaults.cfg
 
     - name: build rpm
-      run: mock -r /etc/mock/${{ matrix.target }}-x86_64.cfg --isolation=simple --resultdir=rpms/ *.src.rpm
+      run: mock -r /etc/mock/${{ matrix.target }}-x86_64.cfg --verbose --isolation=simple --resultdir=rpms/ *.src.rpm
 
     - name: upload rpm
       uses: 'actions/upload-artifact@v2'


### PR DESCRIPTION
This PR includes the following changes:
- output the testlog directly, so that one sees the failure reason in github actions and doesn't have to download the artifacts
- increase the verbosity of `mock` when building rpms
- add cache of the mock root, this should speed up rpmbuilds considerably