### PR TITLE
Increase data size of tuning_params_t->kernel_pid_max

### DIFF
--- a/headers/types.h
+++ b/headers/types.h
@@ -58,7 +58,8 @@ typedef struct tuning_params_s {
     unsigned int kernel_sched_wakeup_granularity_ns;
     unsigned int kernel_sched_migration_cost_ns;
     unsigned short kernel_numa_balancing;
-    unsigned short kernel_pid_max;
+    /* According to man proc(5) the maximum value is 2^22 */
+    unsigned int kernel_pid_max;
     unsigned int net_core_netdev_max_backlog;
     unsigned int net_core_netdev_budget;
     unsigned int net_core_somaxconn;


### PR DESCRIPTION
`tuning_params_t->kernel_pid_max` is obtained from `/proc/sys/kernel/pid_max` which defaults to 32768 but can be up to 2^22, which then causes an overflow in `collect_stats.py` (it tries to write the value via FFI, but actually checks the value in contrast to
C, which would just cause UB).
This should reduce the flakiness of the tests.