### PR TITLE
Add infer run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,55 @@ jobs:
         ninja clang-format
         git diff --exit-code
       working-directory: ./build_clang
+
+  infer:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    container:
+      image: docker.io/library/ubuntu:20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: install dependencies
+      run: |
+        apt update
+        apt install -y curl xz-utils clang ninja-build python3-pip pkg-config libnl-3-dev libnl-nf-3-dev libjson-c-dev tzdata libncurses5 jq bash
+        pip3 install meson
+      env:
+        DEBIAN_FRONTEND: noninteractive
+
+    - name: download and install infer
+      run: |
+        curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" | tar -C /opt -xJ
+        ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
+      env:
+        VERSION: 1.0.0
+
+    - name: configure for clang
+      run: /usr/local/bin/meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=release build_clang
+      env:
+        CC: clang
+
+    - name: run infer
+      run: |
+        infer capture --compilation-database build_clang/compile_commands.json
+        infer analyze
+
+    - name: fail if there are issues present
+      run: |
+        if [[ $(jq length ./infer-out/report.json) -ne 0 ]]; then
+            cat ./infer-out/report.txt
+            exit 1
+        fi
+
+    - name: upload infer report
+      uses: 'actions/upload-artifact@v2'
+      if: ${{ always() }}
+      with:
+        name: infer-out
+        path: ./infer-out

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.so
 *.swp
 build/
+infer-out/

--- a/src/phoebe.c
+++ b/src/phoebe.c
@@ -312,6 +312,7 @@ int main(int argc, char **argv) {
         printf("Augmenting data...\n");
 
         pthread_t threads[n_threads];
+        memset(threads, 0, n_threads * sizeof(pthread_t));
         for (unsigned int i = 0; i < n_threads; i++)
             pthread_create(&threads[i], NULL, runStdTraining, NULL);
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include "stats.h"
+#include "types.h"
 #include "utils.h"
 
 // Based on https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt

--- a/src/stats.c
+++ b/src/stats.c
@@ -76,6 +76,10 @@ inline void readCpuStats(cpu_stats_t *stats) {
     /*  cpu user nice system idle iowait irq softirq steal guest guest_nice
      */
     FILE *fp = fopen("/proc/stat", "r");
+    if (fp == NULL) {
+        perror(strerror(errno));
+        exit(EXIT_FAILURE);
+    }
     fgets(str, MAX_PROC_STRING_LENGTH, fp);
     sscanf(str, "%s %u %u %u %u %u %u %u %u %u %u", raw.cpu, &raw.user,
            &raw.nice, &raw.system, &raw.idle, &raw.iowait, &raw.irq,

--- a/src/stats.c
+++ b/src/stats.c
@@ -71,6 +71,7 @@ inline void *collectCpuStats() {
 inline void readCpuStats(cpu_stats_t *stats) {
     char str[MAX_PROC_STRING_LENGTH];
     cpu_raw_stats_t raw;
+    memset(&raw, 0, sizeof(cpu_raw_stats_t));
 
     /*  cpu user nice system idle iowait irq softirq steal guest guest_nice
      */

--- a/src/utils.c
+++ b/src/utils.c
@@ -2,7 +2,6 @@
 // Copyright SUSE LLC
 
 #include <assert.h>
-#include <errno.h>
 #include <limits.h>
 #include <math.h>
 #include <netinet/ip.h>


### PR DESCRIPTION
This PR adds another CI run using [infer](https://fbinfer.com/), a static code analyzer for C/C++, Java and Objective C.

To make the CI green again, I have initialized some uninitialized variables and added a check for `fopen` returning a non `NULL` pointer.