### PR TITLE
Improve spec file & docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         VERSION: 1.0.0
 
     - name: configure for clang
-      run: /usr/local/bin/meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=release -Dwith_tests=false build_clang
+      run: /usr/local/bin/meson -Dprint_advanced_messages=true -Dprint_table=true -Dcheck_initial_settings=true -Dbuildtype=release -Dwith_tests=false -Dcollector=disabled build_clang
       env:
         CC: clang
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,6 +23,9 @@ There are few compile-time flags which can be passed to Meson to enable some cod
 * **apply_changes**: this enables the application to actually apply the settings via `sysctl`/`ethtool` command
 * **check_initial_settings**: when enabled, this will prevent the application from applying lower settings than the ones already applied to the system at bootstrap
 * **m_threads**: when enabled, this will run training using as many threads as available cores on the machine
+* **collector**: when enabled, then the library requirements for the script `collect_stats.py` will be included in the build
+* **with_tests**: the tests will be build as well when enabled (this requires the cmocka library to be installed)
+* **use_linear_regression**: use linear regression as the MI algorithm
 
 These flags can be enabled by passing them to the Meson configure step:
 

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -1,11 +1,14 @@
-systemd = dependency('systemd')
-systemd_system_unit_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
-
+if get_option('systemd_system_unit_dir') == ''
+  systemd = dependency('systemd')
+  systemd_system_unit_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+else
+  systemd_system_unit_dir = get_option('systemd_system_unit_dir')
+endif
 
 configure_file(
-    copy: true,
-    input: 'phoebe.service',
-    install: true,
-    install_dir: systemd_system_unit_dir,
-    output: 'phoebe.service',
+  copy: true,
+  input: 'phoebe.service',
+  install: true,
+  install_dir: systemd_system_unit_dir,
+  output: 'phoebe.service',
 )

--- a/dist/rpm/phoebe.spec
+++ b/dist/rpm/phoebe.spec
@@ -62,16 +62,16 @@ to offer eventually the best possible setup.
 mkdir -p %{buildroot}%{_sbindir}
 ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcphoebe
 
-%pre 
+%pre
 %service_add_pre phoebe.service
 
 %post
 %service_add_post phoebe.service
 
-%preun 
+%preun
 %service_del_preun phoebe.service
 
-%postun 
+%postun
 %service_del_postun phoebe.service
 
 %files

--- a/dist/rpm/phoebe.spec
+++ b/dist/rpm/phoebe.spec
@@ -32,7 +32,7 @@ BuildRequires:  python3-cffi
 BuildRequires:  python3-devel
 BuildRequires:  python3-pycparser
 %{?systemd_ordering}
-BuildRequires:  pkgconfig(systemd)
+BuildRequires:  systemd-rpm-macros
 
 %description
 
@@ -54,7 +54,7 @@ to offer eventually the best possible setup.
 %build
 # export build flags manually if %%set_build_flags is not defined
 %{?!set_build_flags:export CFLAGS="%{optflags}"; export LDFLAGS="${RPM_LD_FLAGS}"}
-%meson -Dwith_tests=false
+%meson -Dwith_tests=false -Dsystemd_system_unit_dir=%{_unitdir}
 %meson_build
 
 %install

--- a/dist/rpm/phoebe.spec
+++ b/dist/rpm/phoebe.spec
@@ -59,9 +59,12 @@ to offer eventually the best possible setup.
 
 %install
 %meson_install
+%if 0%{?suse_version}
 mkdir -p %{buildroot}%{_sbindir}
 ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcphoebe
+%endif
 
+%if 0%{?suse_version}
 %pre
 %service_add_pre phoebe.service
 
@@ -74,6 +77,18 @@ ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcphoebe
 %postun
 %service_del_postun phoebe.service
 
+%else
+
+%post
+%{systemd_post phoebe.service}
+
+%preun
+%{systemd_preun phoebe.service}
+
+%postun
+%{systemd_postun_with_restart phoebe.service}
+%endif
+
 %files
 %license LICENSE
 %{_bindir}/%{name}
@@ -85,6 +100,8 @@ ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcphoebe
 %{_datadir}/%{name}/rates.csv
 %config(noreplace) %{_sysconfdir}/%{name}/settings.json
 %{_unitdir}/phoebe.service
+%if 0%{?suse_version}
 %{_sbindir}/rcphoebe
+%endif
 
 %changelog

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,4 +34,7 @@ option(
   'use_linear_regression', type : 'boolean', value : true,
   description : 'it is enabled by default to make Phoebe use the linear regression algorithm'
 )
-
+option(
+  'systemd_system_unit_dir', type : 'string',
+  description : 'Folder into which phoebe.service is installed'
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,7 +23,7 @@ option(
   description : 'when enabled will run training using as many threads as cores are available on the machine'
 )
 option(
-  'collector', type : 'feature', value : 'auto',
+  'collector', type : 'feature', value : 'enabled',
   description : 'when enabled will build library requires for collect_stats.py, which is used to collect system metrics to train the AI model'
 )
 option(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,11 +28,11 @@ option(
 )
 option(
   'with_tests', type : 'boolean', value : true,
-  description : 'when enabled, then the tests will be build and run as well'
+  description : 'build and run the tests as well when enabled'
 )
 option(
   'use_linear_regression', type : 'boolean', value : true,
-  description : 'it is enabled by default to make Phoebe use the linear regression algorithm'
+  description : 'Phoebe will use the linear regression algorithm when enabled'
 )
 option(
   'systemd_system_unit_dir', type : 'string',


### PR DESCRIPTION
- don't use suse constructs in non-suse distros
- remove hard dependency on systemd
- document build options and enable the collector by default
- initiated by #38