### PR TITLE
collect_stats: copy _phobe lib into common place

### DIFF
--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -12,9 +12,10 @@ abi_src = custom_target(
   output : ['_phoebe.c'],
   command : [prog_python, '@INPUT@', 'generate', '@OUTPUT@'],
 )
-abi = shared_library(
-  '_phoebe.abi3',
+abi = prog_python.extension_module(
+  '_phoebe',
   abi_src, stat_src, common_src,
-  name_prefix : '',
   dependencies : [prog_python.dependency(embed : true), common_dep, nl_nf_3],
+  install: true,
+  install_dir : prog_python.get_install_dir()
 )


### PR DESCRIPTION
Before this execution of collect_stats.py was possible only with custom
PYTHONPATH. Now you can run collect_stats without any extra setup